### PR TITLE
 Set site_link in default and example config 

### DIFF
--- a/build.py
+++ b/build.py
@@ -282,6 +282,7 @@ DEFAULT_CONFIG: Config = {
 		FrontmatterKeys.index_sort_key: "title",
 		FrontmatterKeys.index_sort_reverse: False,
 	},
+	"site_link": None,
 }
 
 def update_extras(config: Config) -> None:

--- a/example/config.yml
+++ b/example/config.yml
@@ -46,6 +46,8 @@ build_time_fname": ".build_time"
 # use dotlist hierarchy if true, folder hierarchy if false. this will mess with relative paths in the markdown files
 dotlist_hierarchy: true
 
+site_link: "https://mivanit.github.io/pandoc-sitegen"
+
 # pandoc stuff
 # ==============================
 # these items will be passed as arguments to pandoc


### PR DESCRIPTION
It's set to None in the default config (so as to generate an error that
would force the user to enter a sensible value) and to
"https://mivanit.github.io/pandoc-sitegen" for the example config (which
is the URL that the example is deployed to.)